### PR TITLE
処理済みと完了の場合は集計と枠線をつけないように修正 #

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Backlogアジャイル開発用拡張機能",
   "author": "pawn",
   "description": "Backlogのボードでアジャイル開発のストーリポイントを表示するための拡張機能",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "manifest_version": 3,
   "icons": {
     "48": "images/31_Good-job_e.png"

--- a/script/script.js
+++ b/script/script.js
@@ -37,8 +37,16 @@ if(url.indexOf('backlog.jp/board/')!=-1){
 
       listElementsArray.forEach(function(element) {
         let titleElements = element.getElementsByClassName("css-e9ni64-box");
+        let closeTaskList=false;
 
         let titleElementsArray = Array.from(titleElements);
+        titleElementsArray.forEach(function(titleElements) {
+          if(titleElements.tagName == "SPAN" || titleElements.tagName =="span"){
+            if(titleElements.innerText=="完了" || titleElements.innerText=="処理済み"){
+              closeTaskList=true;
+            }
+          }
+        });
 
         let cardElements = element.getElementsByClassName("card-summary");
 
@@ -70,66 +78,70 @@ if(url.indexOf('backlog.jp/board/')!=-1){
                 cardElements.parentNode.style.backgroundColor = safetyLevel;
               }
             }
-            let limitDate=cardElements.parentNode.querySelectorAll('input[aria-label]');
-            if(limitDate.length>0){
-              let limitDateValue = limitDate[0].value;
-              if(limitDateValue.match(/^\d{4}\/\d{2}\/\d{2}$/)){
-                let limitDateValueDate = new Date(limitDateValue);
-                limitDateValueDate.setHours(23);
-                limitDateValueDate.setMinutes(59);
-                let nowDate = new Date();
-                let diffDate = limitDateValueDate - nowDate;
-                if(diffDate<0){
-                  cardElements.parentNode.style.border = overLimitDate;
-                }else{
-                  let nearLimitDateValue = new Date(limitDateValue);
-                  nearLimitDateValue.setHours(23);
-                  nearLimitDateValue.setMinutes(59);
-                  nearLimitDateValue.setDate(nearLimitDateValue.getDate()-1);
-                  diffDate = nearLimitDateValue - nowDate;
+            if(!closeTaskList){
+              let limitDate=cardElements.parentNode.querySelectorAll('input[aria-label]');
+              if(limitDate.length>0){
+                let limitDateValue = limitDate[0].value;
+                if(limitDateValue.match(/^\d{4}\/\d{2}\/\d{2}$/)){
+                  let limitDateValueDate = new Date(limitDateValue);
+                  limitDateValueDate.setHours(23);
+                  limitDateValueDate.setMinutes(59);
+                  let nowDate = new Date();
+                  let diffDate = limitDateValueDate - nowDate;
                   if(diffDate<0){
-                    cardElements.parentNode.style.border = nearLimitDate;
+                    cardElements.parentNode.style.border = overLimitDate;
+                  }else{
+                    let nearLimitDateValue = new Date(limitDateValue);
+                    nearLimitDateValue.setHours(23);
+                    nearLimitDateValue.setMinutes(59);
+                    nearLimitDateValue.setDate(nearLimitDateValue.getDate()-1);
+                    diffDate = nearLimitDateValue - nowDate;{
+                      if(diffDate<0){
+                        cardElements.parentNode.style.border = nearLimitDate;
+                      }
+                    }
                   }
                 }
               }
             }
         });
 
-      
-        titleElementsArray.forEach(function(titleElements) {
-          if(titleElements.tagName == "SPAN" || titleElements.tagName =="span"){
-            let timeElementsScheduledEstimated = titleElements.getElementsByClassName("estimated_time");
-            //timeElementsScheduledがなければ要素を追加する
-            if(timeElementsScheduledEstimated.length == 0){
-              let timeElements = document.createElement("span");
-              timeElements.className = "estimated_time";
-              timeElements.textContent = "予定:"+estimatedSum;  
-              titleElements.appendChild(timeElements);
-            }else{
-              timeElementsScheduledEstimated[0].textContent = "予定:"+estimatedSum;
-            }
+        if(!closeTaskList){
+          titleElementsArray.forEach(function(titleElements) {
+            if(titleElements.tagName == "SPAN" || titleElements.tagName =="span"){
+              let timeElementsScheduledEstimated = titleElements.getElementsByClassName("estimated_time");
+              //timeElementsScheduledがなければ要素を追加する
+              if(timeElementsScheduledEstimated.length == 0){
+                let timeElements = document.createElement("span");
+                timeElements.className = "estimated_time";
+                timeElements.textContent = "予定:"+estimatedSum;  
+                titleElements.appendChild(timeElements);
+              }else{
+                timeElementsScheduledEstimated[0].textContent = "予定:"+estimatedSum;
+              }
 
-            let timeElementsScheduledPunctuation = titleElements.getElementsByClassName("punctuation");
-            //punctuationScheduledがなければ要素を追加する
-            if(timeElementsScheduledPunctuation.length == 0){
-              let timeElements = document.createElement("span");
-              timeElements.className = "punctuation";
-              timeElements.textContent = "/";  
-              titleElements.appendChild(timeElements);
-            }
+              let timeElementsScheduledPunctuation = titleElements.getElementsByClassName("punctuation");
+              //punctuationScheduledがなければ要素を追加する
+              if(timeElementsScheduledPunctuation.length == 0){
+                let timeElements = document.createElement("span");
+                timeElements.className = "punctuation";
+                timeElements.textContent = "/";  
+                titleElements.appendChild(timeElements);
+              }
 
-            let timeElementsScheduledActual = titleElements.getElementsByClassName("actual_time");
-            //timeElementsScheduledがなければ要素を追加する
-            if(timeElementsScheduledActual.length == 0){
-              let timeElements = document.createElement("span");
-              timeElements.className = "actual_time";
-              timeElements.textContent = "実績:"+actualSum;  
-              titleElements.appendChild(timeElements);
-            }else{
-              timeElementsScheduledActual[0].textContent = "実績:"+actualSum;
+              let timeElementsScheduledActual = titleElements.getElementsByClassName("actual_time");
+              //timeElementsScheduledがなければ要素を追加する
+              if(timeElementsScheduledActual.length == 0){
+                let timeElements = document.createElement("span");
+                timeElements.className = "actual_time";
+                timeElements.textContent = "実績:"+actualSum;  
+                titleElements.appendChild(timeElements);
+              }else{
+                timeElementsScheduledActual[0].textContent = "実績:"+actualSum;
+              }
             }
-          }
-        });
+          });
+        }
      });
       
   } 


### PR DESCRIPTION
## **User description**
処理済みや完了は作業が完了しているはずなので予定と実績の合計は出さなくても良いと判断


___

## **Type**
Enhancement


___

## **Description**
- "完了"または"処理済み"のタスクに対して、予定と実績の合計や期限日の枠線を表示しないように変更しました。
- タスクが"完了"または"処理済み"でない場合のみ、期限日が近いか過ぎている場合に枠線を表示するようにしました。
- 予定と実績の時間を表示するロジックを"完了"または"処理済み"でないタスクに限定して更新しました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>script.js</strong><dd><code>"完了"または"処理済み"のタスクの表示ロジックを改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

script/script.js
<li>"完了"または"処理済み"のタスクに対して、予定と実績の合計や期限日の枠線を表示しないように変更<br> <li> タスクが"完了"または"処理済み"でない場合のみ、期限日が近いか過ぎている場合に枠線を表示<br> <li> 予定と実績の時間を表示するロジックを"完了"または"処理済み"でないタスクに限定して更新<br>


</details>
    

  </td>
  <td><a href="https://github.com/pawn-4-git/backlogAgileExtension/pull/3/files#diff-4dccfa52287c300a49229f1c3769921fc11bf8f42b2250fd5caa5aee45eb4163">+62/-50</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

