### PR TITLE
担当者フィルターの一括解除機能の追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,23 +2,33 @@
   "name": "Backlogアジャイル開発用拡張機能",
   "author": "pawn",
   "description": "Backlogのボードでアジャイル開発のストーリポイントを表示するための拡張機能",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "manifest_version": 3,
   "icons": {
     "48": "images/31_Good-job_e.png"
   },
-  "permissions":[
+  "permissions": [
     "tabs",
     "activeTab"
   ],
   "content_scripts": [
     {
-      "matches": ["https://*.backlog.jp/*", "https://*.backlog.com/*"],
-      "js": ["script/script.js"]
+      "matches": [
+        "https://*.backlog.jp/*",
+        "https://*.backlog.com/*"
+      ],
+      "js": [
+        "script/script.js"
+      ]
     },
     {
-      "matches": ["https://*.backlog.jp/*", "https://*.backlog.com/*"],
-      "css": ["css/style.css"]
+      "matches": [
+        "https://*.backlog.jp/*",
+        "https://*.backlog.com/*"
+      ],
+      "css": [
+        "css/style.css"
+      ]
     }
   ]
 }

--- a/script/script.js
+++ b/script/script.js
@@ -214,7 +214,7 @@ if (url.indexOf('backlog.jp/board/') != -1 || url.indexOf('backlog.com/board/') 
       let accountListSelect = document.createElement("select");
       accountListSelect.id = "accountListSelect";
       accountListSelect.multiple = "multiple";
-      accountListSelect.classList = "accountListSelect";
+      accountListSelect.classList.add('accountListSelect');
       accountListSelect.addEventListener("change", function () {
         filterAccount();
       });
@@ -227,7 +227,7 @@ if (url.indexOf('backlog.jp/board/') != -1 || url.indexOf('backlog.com/board/') 
       accountFilterDialog.appendChild(brElement);
       let allAccountCheckClearbutton = document.createElement("button");
       allAccountCheckClearbutton.textContent = "選択解除";
-      allAccountCheckClearbutton.classList = "accountFilterCloseButton"
+      allAccountCheckClearbutton.classList.add('accountFilterCloseButton');
       allAccountCheckClearbutton.addEventListener("click", function () {
         let filter = document.getElementById("accountListSelect");
         for (let i = 0; i < filter.options.length; i++) {
@@ -239,7 +239,7 @@ if (url.indexOf('backlog.jp/board/') != -1 || url.indexOf('backlog.com/board/') 
       accountFilterDialog.appendChild(allAccountCheckClearbutton);
       let accountFilterCloseButton = document.createElement("button");
       accountFilterCloseButton.textContent = "閉じる";
-      accountFilterCloseButton.classList = "accountFilterCloseButton"
+      accountFilterCloseButton.classList.add('accountFilterCloseButton');
       accountFilterCloseButton.addEventListener("click", function () {
         let dialog = document.getElementById("accountFilterDialog");
         dialog.close();
@@ -252,10 +252,17 @@ if (url.indexOf('backlog.jp/board/') != -1 || url.indexOf('backlog.com/board/') 
         let accountFilterButtonElement = document.createElement("button");
         let accountFilterButtonTextElement = document.createElement("span");
         accountFilterButtonTextElement.textContent = "担当者複数選択フィルター";
-        accountFilterButtonTextElement.classList = "_assistive-text";
+        accountFilterButtonTextElement.classList.add('_assistive-text');
         accountFilterButtonElement.id = "accountFilterButton";
         accountFilterButtonElement.type = "button";
-        accountFilterButtonElement.classList = "icon-button icon-button--default title-group__edit-actions-item | simptip-position-top simptip-movable simptip-smooth -with-text"
+        accountFilterButtonElement.classList.add('icon-button');
+        accountFilterButtonElement.classList.add('icon-button--default');
+        accountFilterButtonElement.classList.add('title-group__edit-actions-item');
+        accountFilterButtonElement.classList.add('simptip-position-top');
+        accountFilterButtonElement.classList.add('simptip-movable');
+        accountFilterButtonElement.classList.add('simptip-smooth');
+        accountFilterButtonElement.classList.add('-with-text');
+
         accountFilterButtonElement.appendChild(accountFilterButtonTextElement);
         accountFilterButtonElement.addEventListener("click", function () {
           let dialog = document.getElementById("accountFilterDialog");

--- a/script/script.js
+++ b/script/script.js
@@ -225,6 +225,18 @@ if (url.indexOf('backlog.jp/board/') != -1 || url.indexOf('backlog.com/board/') 
       accountFilterDialog.appendChild(accountListSelect);
       let brElement = document.createElement("br");
       accountFilterDialog.appendChild(brElement);
+      let allAccountCheckClearbutton = document.createElement("button");
+      allAccountCheckClearbutton.textContent = "選択解除";
+      allAccountCheckClearbutton.classList = "accountFilterCloseButton"
+      allAccountCheckClearbutton.addEventListener("click", function () {
+        let filter = document.getElementById("accountListSelect");
+        for (let i = 0; i < filter.options.length; i++) {
+          let option = filter.options[i];
+          option.selected = false;
+        }
+        filterAccount();
+      });
+      accountFilterDialog.appendChild(allAccountCheckClearbutton);
       let accountFilterCloseButton = document.createElement("button");
       accountFilterCloseButton.textContent = "閉じる";
       accountFilterCloseButton.classList = "accountFilterCloseButton"


### PR DESCRIPTION
### **PR Type**
Enhancement, Other


___

### **Description**
- 担当者フィルターの一括解除機能を追加し、ユーザーが全ての選択を一度に解除できるようにしました。
- マニフェストファイルのバージョンを1.3.2に更新し、JSONフォーマットを修正しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>script.js</strong><dd><code>担当者フィルターの一括解除機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

script/script.js
- 担当者フィルターの一括解除ボタンを追加
- ボタンのクリックイベントで全ての選択を解除



</details>
    

  </td>
  <td><a href="https://github.com/pawn-4-git/backlogAgileExtension/pull/6/files#diff-4dccfa52287c300a49229f1c3769921fc11bf8f42b2250fd5caa5aee45eb4163">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Other
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>マニフェストファイルのバージョン更新とフォーマット修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest.json
- バージョンを1.3.2に更新
- JSONフォーマットの修正



</details>
    

  </td>
  <td><a href="https://github.com/pawn-4-git/backlogAgileExtension/pull/6/files#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743">+17/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

